### PR TITLE
Removes keySet() from Environment and SystemProperties Resolvers

### DIFF
--- a/src/main/java/com/hubspot/liveconfig/resolver/EnvironmentResolver.java
+++ b/src/main/java/com/hubspot/liveconfig/resolver/EnvironmentResolver.java
@@ -4,9 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.Maps;
 
-import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 public class EnvironmentResolver extends ForwardingMapResolver {
 
@@ -24,11 +22,6 @@ public class EnvironmentResolver extends ForwardingMapResolver {
   @Override
   protected Map<String, String> delegate() {
     return envMap;
-  }
-
-  @Override
-  public Set<String> keySet() {
-    return Collections.emptySet();
   }
 
   private static Map<String, String> transformEnvMap(Map<String, String> envMap) {

--- a/src/main/java/com/hubspot/liveconfig/resolver/SystemPropertiesResolver.java
+++ b/src/main/java/com/hubspot/liveconfig/resolver/SystemPropertiesResolver.java
@@ -2,9 +2,7 @@ package com.hubspot.liveconfig.resolver;
 
 import com.google.common.collect.Maps;
 
-import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 public class SystemPropertiesResolver extends ForwardingMapResolver {
 
@@ -17,10 +15,5 @@ public class SystemPropertiesResolver extends ForwardingMapResolver {
   @Override
   protected Map<String, String> delegate() {
     return properties;
-  }
-
-  @Override
-  public Set<String> keySet() {
-    return Collections.emptySet();
   }
 }

--- a/src/test/java/com/hubspot/liveconfig/resolver/EnvironmentResolverTest.java
+++ b/src/test/java/com/hubspot/liveconfig/resolver/EnvironmentResolverTest.java
@@ -27,7 +27,7 @@ public class EnvironmentResolverTest {
 
   @Test
   public void testKeySet() {
-    Assert.assertEquals(Collections.<String>emptySet(), resolver.keySet());
+    Assert.assertEquals(Collections.singleton("build.info"), resolver.keySet());
   }
 
 }


### PR DESCRIPTION
- Allows `@Named` to be used with environment variables and SystemProperties
- ForwardingMapResolver will handle keySet() based on envMap